### PR TITLE
ContentPackMaker V3

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,8 @@
+Required: Panda3D with "multify.exe" from: https://www.panda3d.org/download/ or https://github.com/panda3d (Panda3D /w Python is recommended for Toontown.)
+
+How to use:
+Put the files into Pack_Test folder
+
+Extract / Intract the files:
+Resources folder > Extract.bat or Intract.bat
+The files should be done when cmd is completed in Pack_Test Folder

--- a/resources/Extract.bat
+++ b/resources/Extract.bat
@@ -1,0 +1,2 @@
+cd ../Pack_Test
+Multify -x -f *

--- a/resources/Intract.bat
+++ b/resources/Intract.bat
@@ -1,0 +1,2 @@
+cd ../Pack_Test
+Multify -c -f ContentPack.mf *


### PR DESCRIPTION
Changed the resource codings (.bat) to support every type of file within the Pack_Test folder. "Addfolder.txt" is not needed and should be removed after its downloaded. Panda3D download is still required to make this setup to work.

ONLY WORKS WITH WINDOWS AT THIS TIME.